### PR TITLE
SPA fix for nginx

### DIFF
--- a/docker/files/nginx/nginx.conf
+++ b/docker/files/nginx/nginx.conf
@@ -20,6 +20,6 @@ server {
     index index.html index.htm;
 
     location / {
-        try_files $uri $uri/ =404;
+        try_files $uri $uri/ /index.html;
     }
 }


### PR DESCRIPTION
The issue which only certain pages are accessible (such as the landing page, about, login, signup, contact) and others like /team, /dashboard, /apisecurity returning a 404 error is typical of single-page applications (SPAs) served by servers not configured to handle frontend routing correctly.

For SPAs like those built with React, when we navigate directly to a URL or refresh the page, the server needs to return the main index.html page and let React handle the routing on the client side. The current Nginx configuration we had does not support this behavior for paths other than /. It tries to find a physical file for each URL, and when it fails (because those files don't exist, as they are virtual routes handled by React), it returns a 404 error.

**Solution:**

To fix this issue, I need to modify the location / block in Nginx configuration to always serve the index.html file for any path, except for files that actually exist (like CSS, JS, images, etc.). This lets the React router handle the routing.